### PR TITLE
Improving the instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Install the package via ``pip``::
 
     pip install sentry-github
 
-You'll have to create an application in GitHub to get the app ID and API secret. Use the following for the Authentication redirect URL 
+You'll have to create an application in GitHub to get the app ID and API secret. Use the following for the Authentication redirect URL::
 
     <URL_TO_SENTRY>/account/settings/social/complete/github/
 


### PR DESCRIPTION
- GitHub now (did it not in the past?) requires an authentication redirect URL, so the required value is included
- On the new application page, GitHub calls the app ID the "Client ID" and the API secret the "Client Secret". Little hints have been added to the README to indicate this.
