### PR TITLE
Create GitHub issues with requests instead of urllib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'sentry>=5.0.0',
+    'sentry>=7.0.0',
 ]
 
 setup(


### PR DESCRIPTION
Sentry depends on `requests` anyway, why not using it here? This also fixes a bug of nonexistent `sentry.utils.json.load()`