### PR TITLE
add ability to unlink and link existing issues

### DIFF
--- a/src/sentry_github/plugin.py
+++ b/src/sentry_github/plugin.py
@@ -6,11 +6,16 @@ sentry_github.plugin
 :license: BSD, see LICENSE for more details.
 """
 import requests
+from urllib import urlencode
 from django import forms
+from django.contrib import messages
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
+from sentry.plugins.base import JSONResponse
 from sentry.plugins.bases.issue import IssuePlugin, NewIssueForm
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 
 import sentry_github
 
@@ -48,11 +53,26 @@ class GitHubNewIssueForm(NewIssueForm):
         self.fields['assignee'].choices = assignee_choices
 
 
+class GitHubExistingIssueForm(forms.Form):
+    issue_id = forms.CharField(
+        label=_('Issue'),
+        widget=forms.TextInput(attrs={'class': 'issue-selector'}),
+        help_text=mark_safe(_('You can use any syntax supported by GitHub\'s '
+                              '<a href="https://help.github.com/articles/searching-issues/" '
+                              'target="_blank">issue search</a>.')))
+    comment = forms.CharField(
+        label=_('GitHub Comment'),
+        widget=forms.Textarea,
+        required=False,
+        help_text=_('Leave blank if you don\'t want to add a comment to the GitHub issue'))
+
+
 class GitHubPlugin(IssuePlugin):
     author = 'Sentry Team'
     author_url = 'https://github.com/getsentry/sentry'
     version = sentry_github.VERSION
     new_issue_form = GitHubNewIssueForm
+    link_issue_form = GitHubExistingIssueForm
     description = "Integrate GitHub issues by linking a repository to a project."
     resource_links = [
         ('Bug Tracker', 'https://github.com/getsentry/sentry-github/issues'),
@@ -65,12 +85,18 @@ class GitHubPlugin(IssuePlugin):
     conf_key = 'github'
     project_conf_form = GitHubOptionsForm
     auth_provider = 'github'
+    create_issue_template = 'sentry_github/create_github_issue.html'
+    can_unlink_issues = True
+    can_link_existing_issues = True
 
     def is_configured(self, request, project, **kwargs):
         return bool(self.get_option('repo', project))
 
     def get_new_issue_title(self, **kwargs):
-        return 'Create GitHub Issue'
+        return 'Link GitHub Issue'
+
+    def get_unlink_issue_title(self, **kwargs):
+        return 'Unlink GitHub Issue'
 
     def get_new_issue_read_only_fields(self, **kwargs):
         group = kwargs.get('group')
@@ -78,24 +104,37 @@ class GitHubPlugin(IssuePlugin):
             return [{'label': 'Github Repository', 'value': self.get_option('repo', group.project)}]
         return []
 
+    def handle_api_error(self, request, error):
+        msg = _('Error communicating with GitHub: %s') % error
+        messages.add_message(request, messages.ERROR, msg)
+
     def get_allowed_assignees(self, request, group):
         try:
-            req = self.make_api_request(request, group, 'assignees')
+            url = self.build_api_url(group, 'assignees')
+            req = self.make_api_request(request, url)
             body = safe_urlread(req)
-        except requests.RequestException:
+        except requests.RequestException as e:
+            msg = unicode(e)
+            self.handle_api_error(request, msg)
             return tuple()
 
         try:
             json_resp = json.loads(body)
-        except ValueError:
+        except ValueError as e:
+            msg = unicode(e)
+            self.handle_api_error(request, msg)
             return tuple()
 
         if req.status_code > 399:
+            self.handle_api_error(request, json_resp.get('message', ''))
             return tuple()
 
         users = tuple((u['login'], u['login']) for u in json_resp)
 
         return (('', 'Unassigned'),) + users
+
+    def get_initial_link_form_data(self, request, group, event, **kwargs):
+        return {'comment': absolute_uri(group.get_absolute_url())}
 
     def get_new_issue_form(self, request, group, event, **kwargs):
         """
@@ -105,15 +144,21 @@ class GitHubPlugin(IssuePlugin):
                                    request.POST or None,
                                    initial=self.get_initial_form_data(request, group, event))
 
-    def make_api_request(self, request, group, github_api, json_data=None):
-        auth = self.get_auth_for_user(user=request.user)
-        if auth is None:
-            raise forms.ValidationError(_('You have not yet associated GitHub with your account.'))
-
+    def build_api_url(self, group, github_api, query_params=None):
         repo = self.get_option('repo', group.project)
         endpoint = self.get_option('endpoint', group.project) or 'https://api.github.com'
 
         url = '%s/repos/%s/%s' % (endpoint, repo, github_api,)
+
+        if query_params:
+            url = '%s?%s' % (url, urlencode(query_params))
+
+        return url
+
+    def make_api_request(self, request, url, json_data=None):
+        auth = self.get_auth_for_user(user=request.user)
+        if auth is None:
+            raise forms.ValidationError(_('You have not yet associated GitHub with your account.'))
 
         req_headers = {
             'Authorization': 'token %s' % auth.tokens['access_token'],
@@ -129,7 +174,8 @@ class GitHubPlugin(IssuePlugin):
         }
 
         try:
-            req = self.make_api_request(request, group, 'issues', json_data=json_data)
+            url = self.build_api_url(group, 'issues')
+            req = self.make_api_request(request, url, json_data=json_data)
             body = safe_urlread(req)
         except requests.RequestException as e:
             msg = unicode(e)
@@ -146,6 +192,27 @@ class GitHubPlugin(IssuePlugin):
 
         return json_resp['number']
 
+    def link_issue(self, request, group, form_data, **kwargs):
+        comment = form_data.get('comment')
+        if not comment:
+            return
+        url = '%s/%s/comments' % (self.build_api_url(group, 'issues'), form_data['issue_id'])
+        try:
+            req = self.make_api_request(request, url, json_data={'body': comment})
+            body = safe_urlread(req)
+        except requests.RequestException as e:
+            msg = unicode(e)
+            raise forms.ValidationError(_('Error communicating with GitHub: %s') % (msg,))
+
+        try:
+            json_resp = json.loads(body)
+        except ValueError as e:
+            msg = unicode(e)
+            raise forms.ValidationError(_('Error communicating with GitHub: %s') % (msg,))
+
+        if req.status_code > 399:
+            raise forms.ValidationError(json_resp['message'])
+
     def get_issue_label(self, group, issue_id, **kwargs):
         return 'GH-%s' % issue_id
 
@@ -155,3 +222,44 @@ class GitHubPlugin(IssuePlugin):
         github_url = self.get_option('github_url', group.project) or 'https://github.com'
 
         return '%s/%s/issues/%s' % (github_url, repo, issue_id)
+
+    def get_issue_title_by_id(self, request, group, issue_id):
+        url = '%s/%s' % (self.build_api_url(group, 'issues'), issue_id)
+        req = self.make_api_request(request, url)
+
+        body = safe_urlread(req)
+        json_resp = json.loads(body)
+        return json_resp['title']
+
+    def view(self, request, group, **kwargs):
+        if request.GET.get('autocomplete_query'):
+            query = request.GET.get('q')
+            if not query:
+                return JSONResponse({'issues': []})
+            repo = self.get_option('repo', group.project)
+            query = 'repo:%s %s' % (repo, query)
+            endpoint = self.get_option('endpoint', group.project) or 'https://api.github.com'
+            url = '%s/search/issues?%s' % (endpoint, urlencode({'q': query}))
+
+            try:
+                req = self.make_api_request(request, url)
+                body = safe_urlread(req)
+            except requests.RequestException as e:
+                msg = unicode(e)
+                self.handle_api_error(request, msg)
+                return JSONResponse({}, status_code=502)
+
+            try:
+                json_resp = json.loads(body)
+            except ValueError as e:
+                msg = unicode(e)
+                self.handle_api_error(request, msg)
+                return JSONResponse({}, status_code=502)
+
+            issues = [{
+                'text': '(#%s) %s' % (i['number'], i['title']),
+                'id': i['number']
+            } for i in json_resp.get('items', [])]
+            return JSONResponse({'issues': issues})
+
+        return super(GitHubPlugin, self).view(request, group, **kwargs)

--- a/src/sentry_github/templates/sentry_github/create_github_issue.html
+++ b/src/sentry_github/templates/sentry_github/create_github_issue.html
@@ -1,0 +1,27 @@
+{% extends "sentry/plugins/bases/issue/create_issue.html" %}
+
+{% block meta %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $('form .issue-selector').each(function(i, el) {
+                var $el = $(el);
+                $el.select2({
+                    placeholder: 'Start typing to search for an issue',
+                    minimumInputLength: 1,
+                    ajax: {
+                        quietMillis: 100,
+                        url: '?autocomplete_query=1',
+                        dataType: 'json',
+                        data: function(q) {
+                            return {q: q};
+                        },
+                        results: function(data) {
+                            return {results: data.issues};
+                        }
+                    }
+                })
+            });
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
![screenshot 2016-06-15 16 38 00](https://cloud.githubusercontent.com/assets/5026776/16101065/a528120c-3317-11e6-9ba5-a41cf764ab2f.png)
![screenshot 2016-06-15 16 40 27](https://cloud.githubusercontent.com/assets/5026776/16101134/33ab0728-3318-11e6-975b-f7d9282fabb9.png)

- also changed text on button from 'Create GitHub Issue' to 'Link GitHub Issue' so it's more generic
- also added linking existing issues to the activity stream (but not unlinking issues... not sure if we want that?)

@getsentry/api 