### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Install the package via ``pip``::
 
 You'll have to create an application in GitHub to get the app ID and API secret. Use the following for the Authentication redirect URL::
 
-    <URL_TO_SENTRY>/account/settings/social/complete/github/
+    <URL_TO_SENTRY>/account/settings/social/associate/complete/github/
 
 Ensure you've configured GitHub auth in Sentry::
 


### PR DESCRIPTION
Recent versions of sentry use another endpoint which should be reflected in the docs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-github/40)

<!-- Reviewable:end -->
